### PR TITLE
Updated for Discord.NET v2.2.0

### DIFF
--- a/Discord.Addons.Interactive.sln
+++ b/Discord.Addons.Interactive.sln
@@ -7,8 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Discord.Addons.Interactive"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShardedSampleBot", "ShardedSampleBot\ShardedSampleBot.csproj", "{AE0D5578-B834-4F72-9403-39520E0CD407}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SocketSampleBot", "SocketSampleBot\SocketSampleBot.csproj", "{31B0BB55-F964-48E9-A355-E804EECDE43E}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,10 +21,6 @@ Global
 		{AE0D5578-B834-4F72-9403-39520E0CD407}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AE0D5578-B834-4F72-9403-39520E0CD407}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AE0D5578-B834-4F72-9403-39520E0CD407}.Release|Any CPU.Build.0 = Release|Any CPU
-		{31B0BB55-F964-48E9-A355-E804EECDE43E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{31B0BB55-F964-48E9-A355-E804EECDE43E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{31B0BB55-F964-48E9-A355-E804EECDE43E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{31B0BB55-F964-48E9-A355-E804EECDE43E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Discord.Addons.Interactive/Discord.Addons.Interactive.csproj
+++ b/Discord.Addons.Interactive/Discord.Addons.Interactive.csproj
@@ -24,8 +24,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net.Commands" Version="1.0.1" />
-    <PackageReference Include="Discord.Net.WebSocket" Version="1.0.1" />
+    <PackageReference Include="Discord.Net.Commands" Version="2.2.0" />
+    <PackageReference Include="Discord.Net.WebSocket" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/Discord.Addons.Interactive/Discord.Addons.Interactive.csproj
+++ b/Discord.Addons.Interactive/Discord.Addons.Interactive.csproj
@@ -24,8 +24,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net.Commands" Version="2.2.0" />
-    <PackageReference Include="Discord.Net.WebSocket" Version="2.2.0" />
+    <PackageReference Include="Discord.Net" Version="2.3.0-dev-20201117.8" />
+    <PackageReference Include="Discord.Net.Commands" Version="2.3.0-dev-20201117.8" />
+    <PackageReference Include="Discord.Net.WebSocket" Version="2.3.0-dev-20201117.8" />
   </ItemGroup>
 
 </Project>

--- a/Discord.Addons.Interactive/InteractiveBase.cs
+++ b/Discord.Addons.Interactive/InteractiveBase.cs
@@ -1,4 +1,6 @@
-﻿namespace Discord.Addons.Interactive
+﻿using Discord.Addons.Interactive.Results;
+
+namespace Discord.Addons.Interactive
 {
     using System;
     using System.Threading.Tasks;

--- a/Discord.Addons.Interactive/Results/OkResult.cs
+++ b/Discord.Addons.Interactive/Results/OkResult.cs
@@ -1,7 +1,7 @@
-﻿namespace Discord.Addons.Interactive
-{
-    using Discord.Commands;
+﻿using Discord.Commands;
 
+namespace Discord.Addons.Interactive.Results
+{
     /// <summary>
     /// The ok result.
     /// </summary>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# This fork has been deprecated. I will no longer be updating this fork.
+**NOTE: This fork has been deprecated. I will no longer be updating this fork.**
 
 
 # Interactive

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# This fork has been deprecated. I will no longer be updating this fork.
+
+
 # Interactive
 
 An addon for [Discord.Net](https://github.com/RogueException/Discord.Net) that adds interactivity to your commands.

--- a/ShardedSampleBot/CommandHandler.cs
+++ b/ShardedSampleBot/CommandHandler.cs
@@ -1,15 +1,13 @@
-﻿namespace SampleBot
+﻿using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Discord;
+using Discord.Commands;
+using Discord.WebSocket;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ShardedSampleBot
 {
-    using System;
-    using System.Reflection;
-    using System.Threading.Tasks;
-
-    using Discord;
-    using Discord.Commands;
-    using Discord.WebSocket;
-
-    using Microsoft.Extensions.DependencyInjection;
-
     /// <summary>
     /// The command handler.
     /// </summary>

--- a/ShardedSampleBot/Program.cs
+++ b/ShardedSampleBot/Program.cs
@@ -1,16 +1,14 @@
-﻿namespace SampleBot
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Discord;
+using Discord.Addons.Interactive;
+using Discord.Commands;
+using Discord.WebSocket;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ShardedSampleBot
 {
-    using System;
-    using System.IO;
-    using System.Threading.Tasks;
-
-    using Discord;
-    using Discord.Addons.Interactive;
-    using Discord.Commands;
-    using Discord.WebSocket;
-
-    using Microsoft.Extensions.DependencyInjection;
-
     /// <summary>
     /// The program.
     /// </summary>

--- a/ShardedSampleBot/ShardedSampleBot.csproj
+++ b/ShardedSampleBot/ShardedSampleBot.csproj
@@ -6,12 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="2.2.0" />
+    <PackageReference Include="Discord.Net" Version="2.3.0-dev-20201117.8" />
+    <PackageReference Include="Discord.Net.Commands" Version="2.3.0-dev-20201117.8" />
+    <PackageReference Include="Discord.Net.WebSocket" Version="2.3.0-dev-20201117.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Discord.Addons.Interactive\Discord.Addons.Interactive.csproj" />
   </ItemGroup>
-
 </Project>

--- a/ShardedSampleBot/ShardedSampleBot.csproj
+++ b/ShardedSampleBot/ShardedSampleBot.csproj
@@ -6,7 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="2.0.1" />
+    <PackageReference Include="Discord.Net" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
v2.2.0 (and beyond) of Discord.NET breaks compatibility with this library. This PR fixes this issue and is used in production with the Kaguya Bot (viewable on my profile).